### PR TITLE
Multiple linters on machine

### DIFF
--- a/e2e_tests.py
+++ b/e2e_tests.py
@@ -30,7 +30,7 @@ class E2eTests(unittest.TestCase):
         load_balancer_api.set_machine_manager(self.load_balancer_url, self.machine_manager_url)
 
     def tearDown(self) -> None:
-        linters = machine_manager_api.get_machines(self.machine_manager_url)
+        linters = machine_manager_api.get_linters(self.machine_manager_url)
         for linter in linters:
             machine_manager_api.kill_linter_instance(self.machine_manager_url, linter.instance_id)
 
@@ -42,13 +42,13 @@ class E2eTests(unittest.TestCase):
     def test_getting_linters(self):
         for i in range(10):
             machine_manager_api.deploy_linter_instance(self.machine_manager_url, "1.0")
-        result = machine_manager_api.get_machines(self.machine_manager_url)
+        result = machine_manager_api.get_linters(self.machine_manager_url)
         self.assertEqual(10, len(result))
 
     def test_spawning_linters(self):
         for i in range(10):
             machine_manager_api.deploy_linter_instance(self.machine_manager_url, "1.0")
-        result = machine_manager_api.get_machines(self.machine_manager_url)
+        result = machine_manager_api.get_linters(self.machine_manager_url)
 
         for linter_instance in result:
             response: LinterResponse = LinterResponse.from_dict(
@@ -58,35 +58,35 @@ class E2eTests(unittest.TestCase):
 
     def test_replacing_linter_with_different_version(self):
         machine_manager_api.deploy_linter_instance(self.machine_manager_url, "1.0")
-        machines = machine_manager_api.get_machines(self.machine_manager_url)
-        self.assertEqual("1.0", machines[0].version)
+        linters = machine_manager_api.get_linters(self.machine_manager_url)
+        self.assertEqual("1.0", linters[0].version)
 
-        machine_manager_api.deploy_linter_instance(self.machine_manager_url, "2.0", machines[0].instance_id)
-        machines = machine_manager_api.get_machines(self.machine_manager_url)
-        self.assertEqual(1, len(machines))
-        self.assertEqual("2.0", machines[0].version)
+        machine_manager_api.deploy_linter_instance(self.machine_manager_url, "2.0", linters[0].instance_id)
+        linters = machine_manager_api.get_linters(self.machine_manager_url)
+        self.assertEqual(1, len(linters))
+        self.assertEqual("2.0", linters[0].version)
 
     def test_killing_linters(self):
         machine_manager_api.deploy_linter_instance(self.machine_manager_url, "1.0")
         machine_manager_api.deploy_linter_instance(self.machine_manager_url, "1.0")
 
-        machines = machine_manager_api.get_machines(self.machine_manager_url)
-        id1 = machines[0].instance_id
-        id2 = machines[1].instance_id
+        linters = machine_manager_api.get_linters(self.machine_manager_url)
+        id1 = linters[0].instance_id
+        id2 = linters[1].instance_id
 
         machine_manager_api.kill_linter_instance(self.machine_manager_url, id1)
 
-        machines = machine_manager_api.get_machines(self.machine_manager_url)
-        self.assertEqual(1, len(machines))
-        self.assertEqual(id2, machines[0].instance_id)
+        linters = machine_manager_api.get_linters(self.machine_manager_url)
+        self.assertEqual(1, len(linters))
+        self.assertEqual(id2, linters[0].instance_id)
 
-    def test_load_balancer_with_no_machines(self):
+    def test_load_balancer_with_no_linters(self):
         response: LinterResponse = LinterResponse.from_dict(
             load_balancer_api.validate(self.load_balancer_url, LinterRequest(language="python", code="x=5")))
 
         self.assertEqual("fail", response.result)
         self.assertEqual(1, len(response.errors))
-        self.assertEqual("No linter machine available", response.errors[0])
+        self.assertEqual("No linter instance available", response.errors[0])
 
     def test_load_balancer_equal_split(self):
         for i in range(10):

--- a/load_balancer.py
+++ b/load_balancer.py
@@ -6,7 +6,7 @@ from schema import LinterResponse, LinterRequest
 
 load_balancer_app = FastAPI()
 
-machine_number = 0
+linter_number = 0
 machine_manager_url = ""
 
 
@@ -25,15 +25,15 @@ def set_machine_manager(machine_manager: str = "") -> None:
 
 @load_balancer_app.post("/validate")
 def validate_file(request: LinterRequest) -> LinterResponse:
-    global machine_number
+    global linter_number
 
-    machines = machine_manager_api.get_machines(machine_manager_url)
+    linters = machine_manager_api.get_linters(machine_manager_url)
 
-    if machine_number >= len(machines):
-        machine_number = 0
+    if linter_number >= len(linters):
+        linter_number = 0
 
-    if len(machines) == 0:
-        return LinterResponse(result="fail", errors=["No linter machine available"], debug=[])
+    if len(linters) == 0:
+        return LinterResponse(result="fail", errors=["No linter instance available"], debug=[])
 
-    machine_number += 1
-    return linter_api.validate(machines[machine_number - 1].address, request)
+    linter_number += 1
+    return linter_api.validate(linters[linter_number - 1].address, request)

--- a/load_balancer.py
+++ b/load_balancer.py
@@ -31,6 +31,8 @@ def validate_file(request: LinterRequest) -> LinterResponse:
     global linter_number
 
     linters = machine_manager_api.get_linters(machine_manager_url)
+    linters.sort(key=lambda linter: linter.instance_id)
+
     if len(linters) == 0:
         return LinterResponse(result="fail", errors=["No linter instance available"], debug=[])
 

--- a/load_balancer.py
+++ b/load_balancer.py
@@ -36,14 +36,16 @@ def validate_file(request: LinterRequest) -> LinterResponse:
     if len(linters) == 0:
         return LinterResponse(result="fail", errors=["No linter instance available"], debug=[])
 
+    local_linter_number = 0
     try:
         lock.acquire()
 
         if linter_number >= len(linters):
             linter_number = 0
 
+        local_linter_number = linter_number
         linter_number += 1
     finally:
         lock.release()
 
-    return linter_api.validate(linters[linter_number - 1].address, request)
+    return linter_api.validate(linters[local_linter_number].address, request)

--- a/local_linter_deployer.py
+++ b/local_linter_deployer.py
@@ -3,12 +3,12 @@ import uuid
 import deploy_utils
 from schema import ExistingInstance
 
-machines = {}
+linters = {}
 
 
 def kill_linter_instance(instance_id):
     print(f"killing instance {instance_id}")
-    machines.pop(instance_id).kill()
+    linters.pop(instance_id).kill()
 
 
 def deploy_linter_instance(linter_version, instance_id=None):
@@ -19,6 +19,6 @@ def deploy_linter_instance(linter_version, instance_id=None):
         kill_linter_instance(instance_id)
     print(f"deploying linter instance with version {linter_version} on instance {instance_id}")
     process, address = deploy_utils.start_fast_api_app("linter")
-    machines[instance_id] = process
+    linters[instance_id] = process
 
     return ExistingInstance(instance_id=instance_id, address=address, version=linter_version)

--- a/machine_manager.py
+++ b/machine_manager.py
@@ -7,7 +7,7 @@ from schema import ExistingInstance
 
 machine_manager_app = FastAPI()
 
-machines = {}
+linters = {}
 
 
 @machine_manager_app.get("/")
@@ -15,19 +15,19 @@ def get_health():
     return "ok manager"
 
 
-@machine_manager_app.get("/machines")
-def get_machines() -> List[ExistingInstance]:
-    return list(machines.values())
+@machine_manager_app.get("/linters")
+def get_linters() -> List[ExistingInstance]:
+    return list(linters.values())
 
 
 @machine_manager_app.post("/deploy-linter-version")
 def deploy_linter_version(linter_version, instance_id=None) -> ExistingInstance:
-    machine = local_linter_deployer.deploy_linter_instance(linter_version, instance_id)
-    machines[machine.instance_id] = machine
-    return machine
+    linter = local_linter_deployer.deploy_linter_instance(linter_version, instance_id)
+    linters[linter.instance_id] = linter
+    return linter
 
 
 @machine_manager_app.post("/kill-linter")
 def kill_linter_instance(instance_id) -> None:
     local_linter_deployer.kill_linter_instance(instance_id)
-    machines.pop(instance_id)
+    linters.pop(instance_id)

--- a/machine_manager_api.py
+++ b/machine_manager_api.py
@@ -5,8 +5,8 @@ import requests
 from schema import ExistingInstance
 
 
-def get_machines(url):
-    result_raw = requests.get(f"{url}/machines").json()
+def get_linters(url):
+    result_raw = requests.get(f"{url}/linters").json()
     print(result_raw)
     return [ExistingInstance.from_json(json.dumps(elem)) for elem in result_raw]
 


### PR DESCRIPTION
In fact the name of the branch is outdated.
I added some locks for fastAPI apps' global state and minor changes.

Our architecture does not need to be changed to enable multiple linters on a machine.
I am thinking that on a GCP we will have them all running from the same IP, but different ports and then we would need to write new (non local) deployment nonetheless.